### PR TITLE
Made gMailSessions a global variable

### DIFF
--- a/Gmail.ps.psm1
+++ b/Gmail.ps.psm1
@@ -343,12 +343,16 @@ function Get-Message {
         $gmcr = 'X-GM-RAW "' + ($xgm -join ' ') + '"'
         if ($imap.Length -gt 0) {
             $criteria = $criteria + ' (' + $gmcr + ')'
-        } else {
-            $criteria = $gmcr
-        }
+        } 
     }
+    else {
+            $criteria = "UNSEEN"
+        }
 
-    if ($criteria -eq $null){write-debug "troubleshoot `$criteria"}
+    if ($criteria -eq $null){
+        #if no other valid criteria were provided, at least display unread mail
+        $imap += "UNSEEN"
+        }
 
     $result = $Session.Search('(' + $criteria + ')');
     $i = 1


### PR DESCRIPTION
To prevent the user needing to provide $sessions with every cmdlet, modified some of the functions to search for a global gmailSessions variable instead.  This makes the cmdlets behave much more like the Exchange and Office 365 cmdlets.  Now the user can specify a session once and use it over and over by default.  If they'd like to use a different sessions (gmail account), they simply specify it using the -Session param.
